### PR TITLE
Fixed: Read many times from Shrinksafe input stream as Node can send smaller chunks

### DIFF
--- a/packages/shrinksafe/lib/minify/shrinksafe.js
+++ b/packages/shrinksafe/lib/minify/shrinksafe.js
@@ -29,10 +29,15 @@ function compressSingle(code, options) {
     try {
         p.stdin.write(code).close();
 
-        if (p.wait() !== 0)
-            throw new Error("ShrinkSafe error: " + p.stderr.read());
+        //Next two lines does not work with JSC. It just hangs here
+        //if (p.wait() !== 0)
+        //    throw new Error("ShrinkSafe error: " + p.stderr.read());
 
-        return p.stdout.read();
+        var r, result = "";
+        while (r = p.stdout.read()) {
+           result += r
+        }
+        return result;
     } finally {
         p.stdin.close();
         p.stdout.close();


### PR DESCRIPTION
Also removed a error check that does not work with JSC